### PR TITLE
Feature/cell as datasource

### DIFF
--- a/Sources/Collections/SkeletonCollectionDataSource.swift
+++ b/Sources/Collections/SkeletonCollectionDataSource.swift
@@ -36,8 +36,12 @@ extension SkeletonCollectionDataSource: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cellIdentifier = originalTableViewDataSource?.collectionSkeletonView(tableView, cellIdentifierForRowAt: indexPath) ?? ""
-        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
+        guard let cell = originalTableViewDataSource?.collectionSkeletonView(tableView, cellForRowAt: indexPath) else {
+            let cellIdentifier = originalTableViewDataSource?.collectionSkeletonView(tableView, cellIdentifierForRowAt: indexPath) ?? ""
+            let cellFromId = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
+            skeletonViewIfContainerSkeletonIsActive(container: tableView, view: cellFromId)
+            return cellFromId
+        }
         skeletonViewIfContainerSkeletonIsActive(container: tableView, view: cell)
         return cell
     }

--- a/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
+++ b/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
@@ -12,6 +12,7 @@ public protocol SkeletonTableViewDataSource: UITableViewDataSource {
     func numSections(in collectionSkeletonView: UITableView) -> Int
     func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection section: Int) -> Int
     func collectionSkeletonView(_ skeletonView: UITableView, cellIdentifierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier
+    func collectionSkeletonView(_ skeletonView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell?
 }
 
 public extension SkeletonTableViewDataSource {
@@ -26,6 +27,10 @@ public extension SkeletonTableViewDataSource {
     @available(*, deprecated, renamed: "collectionSkeletonView(_:cellIdentifierForRowAt:)")
     func collectionSkeletonView(_ skeletonView: UITableView, cellIdenfierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier {
         return collectionSkeletonView(skeletonView, cellIdentifierForRowAt: indexPath)
+    }
+
+    func collectionSkeletonView(_ skeletonView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell? {
+        nil
     }
 }
 


### PR DESCRIPTION
### Summary

I don't know if this still would be helpful, especially nowadays, but sometimes we have a cell that was defined on runtime and did not go to the [UITableView.register()](https://developer.apple.com/documentation/uikit/uitableview/1614888-register) process.

example:
```
func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
        let cellId = "cellId"

        var cell = tableView.dequeueReusableCell(withIdentifier: cellId)
        if cell == nil {
            cell = UITableViewCell(style: .default, reuseIdentifier: cellId)

            // Do some creation setup
        }

        // assign some values
        return cell!
}

```

This PR will add an option to specify a `UITableViewCell`, aside from using a `ReusableCellIdentifier`.

```swift
func collectionSkeletonView(_ skeletonView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell?
```

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
